### PR TITLE
Updates to ICASR website

### DIFF
--- a/about.md
+++ b/about.md
@@ -2,7 +2,7 @@
 layout: doc
 title: About ICASR
 ---
-[Home](index.md)|  
+[Home](index.md)|[About](about.md)|[Resources](resources.md)|[Events](events.md)|[Papers](papers.md)|  
 
 ICASR is an international collaboration between several groups working in systematic reviews, automation, or both. ICASR holds an annual meeting to foster collaboration between groups working on review automation (see Events for a list of past events).
 The 2018 ICASR Organizing Committee includes:  

--- a/events.md
+++ b/events.md
@@ -2,7 +2,7 @@
 layout: doc
 title: ICASR Events
 ---
-[Home](index.md)|  
+[Home](index.md)|[About](about.md)|[Resources](resources.md)|[Events](events.md)|[Papers](papers.md)|   
 
 **2015**  
 This first meeting of the International Collaboration for the Automation of System Reviews (ICASR)  was held on 2 October 2015, Vienna, Austria adjacent to the Cochrane Colloquium. That first meeting established a set of 8 principles for the collaboration aimed at the development and dissemination of automation methods to assist in improving the speed and quality of systematic reviews. [A BMC Systematic Reviews paper detailing those principles is Open Access.](https://systematicreviewsjournal.biomedcentral.com/articles/10.1186/s13643-018-0740-7){:target="_blank"}  

--- a/events.md
+++ b/events.md
@@ -4,22 +4,36 @@ title: ICASR Events
 ---
 [Home](index.md)|[About](about.md)|[Resources](resources.md)|[Events](events.md)|[Papers](papers.md)|   
 
-**2015**  
-This first meeting of the International Collaboration for the Automation of System Reviews (ICASR)  was held on 2 October 2015, Vienna, Austria adjacent to the Cochrane Colloquium. That first meeting established a set of 8 principles for the collaboration aimed at the development and dissemination of automation methods to assist in improving the speed and quality of systematic reviews. [A BMC Systematic Reviews paper detailing those principles is Open Access.](https://systematicreviewsjournal.biomedcentral.com/articles/10.1186/s13643-018-0740-7){:target="_blank"}  
-  
+**2023**
+
+_To be announced_
+
+**2022**
+
+The seventh ICASR meeting was held June 8-9, 2022 at Institut für Qualität und Wirtschaftlichkeit im Gesundheitswesen ([IQWiG](https://www.iqwig.de)) in Köln, Germany.
+
+**2021**
+
+The sixth meeting was held online April 12–16, 2021. The meeting’s theme was ‘Usability’ with specific areas of focused discussions including user experience, interoperability, tool evaluation, workflow integration, and COVID-19.
+
+**2019**
+The fifth meeting was held in Bergen, Norway. The meeting’s theme was "information extraction from text".
+
+**2018**  
+The fourth meeting of the International Collaboration for Automation of Systematic Reviews (ICASR) was held 5–6 November 2019 in The Hague, the Netherlands. It was supported by [ZonMw](https://www.zonmw.nl/en/){:target="_blank"}, The Netherlands Organisation for health research and Development.  
+
+<img src="images/zonmw-logo.png" width="192">
+
+**2017**  
+At the third meeting in London (2017), the group focused on: tools and technologies for automating data extraction; how interoperability between systems might be facilitated; and the need to develop sector-wide evaluation methodologies. Papers resulting from these discussions are currently at peer review.  
+[some impressions from twitter](https://twitter.com/i/moments/1032159990440701952){:target="_blank"}  
+ICASR 2017 was supported by the Eppi Centre, the National Toxicology Program at the National Institutes of Health (contract GS00A14OADU417/HHSN273201600015U), and Iowa State University.  
+<img src="images/eppi_logo.jpg" height="50" width="120"> <img src="images/isu-stacked.svg" height="50" width="192"> <img src="images/Screen Shot 2018-09-10 at 14.28.55.png" height="50" width="192">  
+
 **2016**  
 The second meeting was held in Philadelphia (October 2016) adjacent to the Guidelines-International-Network (G-I-N) meeting. The meeting focused on interoperability of tools, measuring acceleration of systematic review production, automated screening technologies and accommodating variation in requirements of automation tools for different domains such as animal trials and environmental science. [A BMC Systematic Reviews paper detailing those principles is Open Access](https://systematicreviewsjournal.biomedcentral.com/articles/10.1186/s13643-017-0667-4){:target="_blank"}  
 ICASR 2016 was supported by the National Toxicology Program at the National Institutes of Health (contract GS00A14OADU417/HHSN273201600015U) and Iowa State University.  
 <img src="images/isu-stacked.svg" height="50" width="192"> <img src="images/Screen Shot 2018-09-10 at 14.28.55.png" height="50" width="192">
-  
-  
-**2017**  
-At the meeting in London (2017), the group focused on: tools and technologies for automating data extraction; how interoperability between systems might be facilitated; and the need to develop sector-wide evaluation methodologies. Papers resulting from these discussions are currently at peer review.  
-[some impressions from twitter](https://twitter.com/i/moments/1032159990440701952){:target="_blank"}  
-ICASR 2017 was supported by the Eppi Centre, the National Toxicology Program at the National Institutes of Health (contract GS00A14OADU417/HHSN273201600015U), and Iowa State University.  
-<img src="images/eppi_logo.jpg" height="50" width="120"> <img src="images/isu-stacked.svg" height="50" width="192"> <img src="images/Screen Shot 2018-09-10 at 14.28.55.png" height="50" width="192">  
-  
-**2018**  
-A meeting is being planned in the Hague in November supported by [ZonMw](https://www.zonmw.nl/en/){:target="_blank"}, The Netherlands Organisation for health research and Development.  
 
-<img src="images/zonmw-logo.png" width="192">  
+**2015**  
+This first meeting of the International Collaboration for the Automation of System Reviews (ICASR)  was held on 2 October 2015, Vienna, Austria adjacent to the Cochrane Colloquium. That first meeting established a set of 8 principles for the collaboration aimed at the development and dissemination of automation methods to assist in improving the speed and quality of systematic reviews. [A BMC Systematic Reviews paper detailing those principles is Open Access.](https://systematicreviewsjournal.biomedcentral.com/articles/10.1186/s13643-018-0740-7){:target="_blank"}  

--- a/papers.md
+++ b/papers.md
@@ -2,10 +2,11 @@
 layout: doc
 title: Papers
 ---
-[Home](index.md)|  
+[Home](index.md)|[About](about.md)|[Resources](resources.md)|[Events](events.md)|[Papers](papers.md)|
+
 
 O'Connor, A., Tsafnat, G., Gilbert, S., Thayer, K., & Wolfe, M. (2018). Moving toward the automation of the systematic review process: A summary of discussions at the Second Meeting of International Collaboration for the Automation of Systematic Reviews (ICASR). Systematic Reviews, 7(3).
 
 Beller, E., Clark, J., Tsafnat, G., Adams, C., Diehl, H., Lund, H., Ouzzani, M., Thayer, K., Thomas, J., Turner, T., Xia, J., Robinson, Karen., Glasziou, P. (2018). Making progress with the automation of systematic reviews : principles of the International Collaboration for the Automation of Systematic Reviews ( ICASR ), 1–7.
-  
-  [**More**](https://zenodo.org/communities/icasr){:target="_blank"}  
+
+[**More**](https://zenodo.org/communities/icasr){:target="_blank"}  

--- a/papers.md
+++ b/papers.md
@@ -4,6 +4,9 @@ title: Papers
 ---
 [Home](index.md)|[About](about.md)|[Resources](resources.md)|[Events](events.md)|[Papers](papers.md)|
 
+O’Connor, A.M., Glasziou, P., Taylor, M. et al. A focus on cross-purpose tools, automated recognition of study design in multiple disciplines, and evaluation of automation tools: a summary of significant discussions at the fourth meeting of the International Collaboration for Automation of Systematic Reviews (ICASR). Syst Rev 9, 100 (2020).
+
+O’Connor, A. M., Tsafnat, G., Gilbert, S. B., Thayer, K. A., Shemilt, I., Thomas, J., Glasziou, P., & Wolfe, M. S. (2019). Still moving toward automation of the systematic review process: a summary of discussions at the third meeting of the International Collaboration for Automation of Systematic Reviews (ICASR). Systematic reviews, 8(1), 1-5.
 
 O'Connor, A., Tsafnat, G., Gilbert, S., Thayer, K., & Wolfe, M. (2018). Moving toward the automation of the systematic review process: A summary of discussions at the Second Meeting of International Collaboration for the Automation of Systematic Reviews (ICASR). Systematic Reviews, 7(3).
 

--- a/resources.md
+++ b/resources.md
@@ -2,7 +2,7 @@
 layout: doc
 title: Resources
 ---
-[Home](index.md)|  
+[Home](index.md)|[About](about.md)|[Resources](resources.md)|[Events](events.md)|[Papers](papers.md)|   
 
 A list of software to assist with systematic review is available at: [http://systematicreviewtools.com/](http://systematicreviewtools.com/){:target="_blank"}   
 The ICASR group is currently working on sites and processes for making software, code, and datasets publicly available.


### PR DESCRIPTION
- add missing links in the header
- add ICASR papers from 2019-2020
- add information about past ICASR events